### PR TITLE
Updated with UEFI Support and Ubuntu 18.04/18.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # ubuntu-server-auto-install
 
-Creates any Ubuntu server unattended installation iso
+**_PLEASE NOTE: I did not create the base version of this script, nor do I take credit. I made a less functional version building off of the wonderful work by [makelinux](https://github.com/makelinux/ubuntu-server-auto-install) to fit my needs._**
 
-Tested in Ubuntu server versions 12.04 14.04 15.04 16.04 16.10 17.04
+Creates an Ubuntu Server 16.04 unattended installation ISO
+
+_This was originally designed to work with more than just 16.04, but I have no need for backwards compatibility. I am leaving the functionality to download older server versions, however I cannot say they will work, and in fact I presume they do not work._
 
 Features:
 
@@ -17,17 +19,25 @@ Features:
 * Short - about 100 lines of code, easy modifiable
 * Helps to run installation with qemu
 * Suitable for batch installation
+* UEFI & MBR Boot Options
+  * _Works great with Hyper-V Gen1 and Gen2 VMs!_
 
 Interface:
 
 * No arguments - interactive mode. The program requestes desired version XX.YY.
 * Argument - XX.YY of Ubuntu server version. The program finds the third release digit automatically.
-  For example "14.04.5".
+  For example "16.04.4".
 * Argument - word "latest" - the latest release will be selected automatically, for example 17.04.
 * Argument - URL of iso image to download (if need).
 * Argument - name for iso image. Program will search for the file in directory ~/Downloads
 * Output - file ubuntu-XX.YY.ZZ-server-amd64-auto-install.iso
 
+Prerequisites:
+
+* Need the isohdpfx.bin from isolinux. To get it, use `sudo apt install isolinux`
+* Need 'xorriso' installed. To get it, use `sudo apt install xorriso -y`
+
 Limitations:
 
 * Doesn't work with Ubuntu desktop
+* May or may not work with other versions of Ubuntu Server

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # ubuntu-server-auto-install
 
-**_PLEASE NOTE: I did not create the base version of this script, nor do I take credit. I made a less functional version building off of the wonderful work by [makelinux](https://github.com/makelinux/ubuntu-server-auto-install) to fit my needs._**
-
 Creates an Ubuntu Server unattended installation ISO
 
-Tested in Ubuntu Server version 16.04, 18.04
+Tested with Ubuntu Server 14.04, 16.04, 17.10, 18.04 and 18.10
 
-_This was originally designed to work with more than just 16.04/18.04, but I have no need for backwards compatibility. I am leaving the functionality to download older server versions, however I cannot say they will work, and in fact I presume they do not work._
+## Prerequisites
 
-Features:
+* Need the isohdpfx.bin from isolinux. To get it, use `sudo apt install isolinux`
+* Need 'xorriso' installed. To get it, use `sudo apt install xorriso -y`
+
+## Features
 
 * Minimal interaction
 * Downloads available Ubuntu server release from releases.ubuntu.com
@@ -21,10 +22,10 @@ Features:
 * Short - about 100 lines of code, easy modifiable
 * Helps to run installation with qemu
 * Suitable for batch installation
-* UEFI & MBR Boot Options
-  * _Works great with Hyper-V Gen1 and Gen2 VMs!_
+* Works with both UEFI & MBR Boot Options
+  * _Works great with Hyper-V Gen1 and Gen2 VMs! (If using Gen2, set Secure Boot Template to "Microsoft UEFI Certificate Authority"_
 
-Interface:
+## Interface
 
 * No arguments - interactive mode. The program requestes desired version XX.YY.
 * Argument - XX.YY of Ubuntu server version. The program finds the third release digit automatically.
@@ -34,12 +35,8 @@ Interface:
 * Argument - name for iso image. Program will search for the file in directory ~/Downloads
 * Output - file ubuntu-XX.YY.ZZ-server-amd64-auto-install.iso
 
-Prerequisites:
+## Limitations
 
-* Need the isohdpfx.bin from isolinux. To get it, use `sudo apt install isolinux`
-* Need 'xorriso' installed. To get it, use `sudo apt install xorriso -y`
-
-Limitations:
-
-* Doesn't work with Ubuntu desktop
+* Doesn't work with Ubuntu desktop ISOs
 * May or may not work with other versions of Ubuntu Server
+  * _Does not work with Ubuntu Server 12.04_

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 **_PLEASE NOTE: I did not create the base version of this script, nor do I take credit. I made a less functional version building off of the wonderful work by [makelinux](https://github.com/makelinux/ubuntu-server-auto-install) to fit my needs._**
 
-Creates an Ubuntu Server 16.04 unattended installation ISO
+Creates an Ubuntu Server unattended installation ISO
 
-_This was originally designed to work with more than just 16.04, but I have no need for backwards compatibility. I am leaving the functionality to download older server versions, however I cannot say they will work, and in fact I presume they do not work._
+Tested in Ubuntu Server version 16.04, 18.04
+
+_This was originally designed to work with more than just 16.04/18.04, but I have no need for backwards compatibility. I am leaving the functionality to download older server versions, however I cannot say they will work, and in fact I presume they do not work._
 
 Features:
 

--- a/ubuntu-server-auto-install
+++ b/ubuntu-server-auto-install
@@ -60,10 +60,15 @@ ubuntu-server-auto-install()
 	chroot /target update-grub
 	%end
 	EOF
-	mkisofs -q -disable-deep-relocation -rational-rock -cache-inodes -joliet \
-		-full-iso9660-filenames -no-emul-boot -boot-load-size 4 -boot-info-table \
-		-eltorito-boot isolinux/isolinux.bin -eltorito-catalog isolinux/boot.cat \
-		-o $auto.iso $auto
+	xorriso -as mkisofs -isohybrid-mbr /usr/lib/ISOLINUX/isohdpfx.bin \
+		-c isolinux/boot.cat -b isolinux/isolinux.bin \
+		-no-emul-boot -boot-load-size 4 -boot-info-table \
+		-eltorito-alt-boot -e boot/grub/efi.img -no-emul-boot \
+		-isohybrid-gpt-basdat -o $auto.iso $auto
+	#mkisofs -q -disable-deep-relocation -rational-rock -cache-inodes -joliet \
+	#	-full-iso9660-filenames -no-emul-boot -boot-load-size 4 -boot-info-table \
+	#	-eltorito-boot isolinux/isolinux.bin -eltorito-catalog isolinux/boot.cat \
+	#	-o $auto.iso $auto
 	rm -rf $mnt $auto
 	echo Created $auto.iso
 	echo Run test installation with:
@@ -84,6 +89,28 @@ kickstart-cfg()
 		  menu label ^Install Ubuntu Server
 		  kernel /install/vmlinuz
 		  append file=/cdrom/preseed/ubuntu-server.seed initrd=/install/initrd.gz ks=cdrom:/ks.cfg preseed/file=/cdrom/ks.preseed --
+	EOF
+	# add uefi support
+	cat > $1/boot/grub/grub.cfg <<- EOF
+
+		if loadfont /boot/grub/font.pf2 ; then
+		  set gfxmode=auto
+		  insmod efi_gop
+		  insmod efi_uga
+		  insmod gfxterm
+		  terminal_output gfxterm
+		fi
+
+		set default=0
+		set timeout=1
+		set menu_color_normal=white/black
+		set menu_color_highlight=black/light-gray
+		menuentry "Automated Install of Ubuntu Server" {
+		  set gfxpayload=keep
+		  linux /install/vmlinuz  file=/cdrom/preseed/ubuntu-server.seed ks=cdrom:/ks.cfg preseed/file=/cdrom/ks.preseed ---
+		  initrd /install/initrd.gz
+		}
+		}
 	EOF
 	cat > $1/ks.cfg <<- EOF
 		lang en_US.UTF-8

--- a/ubuntu-server-auto-install
+++ b/ubuntu-server-auto-install
@@ -2,8 +2,9 @@
 
 ubuntu-release()
 {
-	# 18.04 and later support
-	if expr match "$1" ".*18..*" > /dev/null; then
+	# 18.04 and later need to use the alternative installer
+	# since the switch to subiquity
+	if [ ${1:0:2} -ge 18 ]; then
         rel=http://cdimage.ubuntu.com/releases/$1/release
 		echo $rel/$(curl --silent $rel/MD5SUMS | \grep -o 'ubuntu-.*-server-amd64.iso')
     else

--- a/ubuntu-server-auto-install
+++ b/ubuntu-server-auto-install
@@ -2,8 +2,14 @@
 
 ubuntu-release()
 {
-	rel=http://releases.ubuntu.com/$1
-	echo $rel/$(curl --silent $rel/MD5SUMS | \grep -o 'ubuntu-.*-server-amd64.iso')
+	# 18.04 and later support
+	if expr match "$1" ".*18..*" > /dev/null; then
+        rel=http://cdimage.ubuntu.com/releases/$1/release
+		echo $rel/$(curl --silent $rel/MD5SUMS | \grep -o 'ubuntu-.*-server-amd64.iso')
+    else
+		rel=http://releases.ubuntu.com/$1
+		echo $rel/$(curl --silent $rel/MD5SUMS | \grep -o 'ubuntu-.*-server-amd64.iso')
+	fi
 }
 
 ubuntu-server-auto-install()


### PR DESCRIPTION
Headlines of the changes I made
* Changed how the ISOs were created in order to provide support both MBR and UEFI boot options at the same time using xorriso.
  * _12.04 no longer works with this new method_
* Added support for 18.04 and 18.10. You have to use the alternate installer locations for these versions due to Ubuntu 18.04 and later now using Subiquity